### PR TITLE
feat: Add domain user id cookie to event protocol

### DIFF
--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,3 +1,5 @@
+import { getCookieDomainUserId } from '../tools/getCookieDomainUserId';
+
 export function generateJson(
   data: unknown,
   schema: string,
@@ -10,6 +12,7 @@ export function generateJson(
         e: 'ue',
         p: 'web',
         tv: 'node-1.0.2',
+        duid: getCookieDomainUserId('_sp_id.1fff'),
         ue_pr: JSON.stringify({
           schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
           data: {

--- a/lib/tools/getCookieDomainUserId.ts
+++ b/lib/tools/getCookieDomainUserId.ts
@@ -1,0 +1,9 @@
+export function getCookieDomainUserId(cookieName) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${cookieName}=`);
+  if (parts.length === 2){
+    return parts.pop()?.split(';').shift()?.split('.')[0]; 
+  } 
+}
+
+export default getCookieDomainUserId;


### PR DESCRIPTION
## What?
Se agregó una función que permite obtener la cookie `domain_userid`, la cual es propia de cada usuario y dura dos años. Luego esta es enviada a través del protocolo Snowplow que permite que todos los eventos custom tengan asociada esta cookie.

## Why?
Esta función se agregó, ya que es importante identificar al usuario que gatilla distintitos eventos custom, además para trabajar con los datos y cruzar tablas de la base de datos, esta cookie facilita mucho este trabajo.
## How?
Para esto se creo una función `getCookieDomainUserId`, la cual recibe el nombre de la cookie en cuestión y retorna la domain user id. Luego esta función es llamada en la funcion generateJson para cumplir con el protocolo de eventos de Snowplow.

## Testing?
Se testeo enviando eventos y que al momento de llegar a la base de datos estos tuvieran la cookie asociada.

## Screenshots


## Anything Else?
**IMPORTANTE**: Esta PR es independiente del resto de las PRs por lo que puede ser revisada y mergeada sin problemas y en cualquier momento.

