### PR TITLE
feat/Add new trackers to library and update old ones

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,3 +142,14 @@ trackStep: {
     ],
 }
 ```
+
+#### trackPagePingExtended
+
+Este es un tracker personalizado de CloudCar y envía eventos al collector cada `time_interval` cantidad de segundos. Este envia información acerca del estado actual del usuario en la página (blur o focus) y la posición del mouse cada `mousePosInterval` segundos.
+
+```
+trackPagePingExtended: {
+    time_interval: 30,
+    mousePosInterval: 2
+}
+```

--- a/README.md
+++ b/README.md
@@ -104,3 +104,22 @@ Este es un tracker personalizado de CloudCar y envía eventos al collector cada 
 ```
 trackTextSelection: true
 ```
+
+#### trackHover
+
+Este es un tracker personalizado de CloudCar y envía eventos al collector cada vez que el usuario hace hover sobre un elemento HTML dentro de la página. Su configuración requiere de una lista de selectores correspondientes al los distintos elementos HTML que se quieren trackear. El evento que se envía consiste de un identificador del vehículo observavodo, un identificador del elemento, el innerText del elemento si es que tiene y el tiempo que el usuario hace hover sobre este.
+        
+```
+trackHover: {
+    selectors: [
+        {
+            selector_id: 'Purcharse Button',
+            css_selector: '.BaseButton_Button',
+        },
+        {
+            selector_id: 'Car Image',
+            css_selector: '.Widget_ImageHeader',
+        },
+    ],
+}
+```

--- a/README.md
+++ b/README.md
@@ -123,3 +123,22 @@ trackHover: {
     ],
 }
 ```
+
+#### trackStep
+
+Este es un tracker personalizado de CloudCar y envía eventos al collector cada vez que el usuario se cambia de step, ya sea a través del botón continuar o un botón step. Su configuración requiere de una lista de selectores correspondientes al los distintos elementos HTML que se quieren trackear. El evento que se envía consiste en el nombre step donde estuvo el usuario, el tiempo que permaneció en el step y un identificador del la compra (purchaseIntentId).
+        
+```
+trackStep: {
+    selectors: [
+        {
+            selector_id: 'Next Button',
+            css_selector: '.ant-btn.NextButton_NextButton__uJhUk.DefaultButton.PrimaryBaseButton',
+        },
+        {
+            selector_id: 'Step Button',
+            css_selector: '.ant-row.ant-row-middle.VerticalStepContainer.ClickableStep',
+        },
+    ],
+}
+```

--- a/lib/config/configTypes.ts
+++ b/lib/config/configTypes.ts
@@ -40,95 +40,98 @@ export type SnowplowConfig = {
         }
         ``` 
         */
-       enableActivityTracking: EnableActivityTracking | boolean;
-       /**
-        * Este es un tracker personalizado de CloudCar y envía eventos 
-        * al collector cada vez que el usuario hace click en algún elemento 
-        * HTML de interés para la organización. Su configuración requiere de 
-        * una lista de selectores correspondientes a los elementos HTML que 
-        * se quieren trackear, junto con un identificador para reconocerlos 
-        * más adelante en la base de datos.
-    
-        ```
-        trackParticularClicks: {
-            selectors: [
-                {
-                    selector_id: 'color 1',
-                    css_selector: 'div.ant-row:nth-child(4) div:nth-child(1)',
-                },
-                {
-                    selector_id: 'color 2',
-                    css_selector: 'div.ant-row:nth-child(4) div:nth-child(2)',
-                },
-            ],
-        }
-        ```
-        */
-       trackParticularClicks?: TrackParticularClicks;
-       /**
-        * Este es otro tracker personalizado de CloudCar y envía eventos 
-        * al collector cada vez que el usuario hace click en el botón de 
-        * compra. Su configuración requiere de una lista de selectores 
-        * correspondientes al botón de compra. El evento que se envía 
-        * consiste de un identificador del vehículo a comprar y el tiempo 
-        * que se demora el usuario en hacer click en el botón desde que 
+    enableActivityTracking: EnableActivityTracking | boolean;
+    /**
+     * Este es un tracker personalizado de CloudCar y envía eventos 
+     * al collector cada vez que el usuario hace click en algún elemento 
+     * HTML de interés para la organización. Su configuración requiere de 
+     * una lista de selectores correspondientes a los elementos HTML que 
+     * se quieren trackear, junto con un identificador para reconocerlos 
+     * más adelante en la base de datos.
+ 
+     ```
+     trackParticularClicks: {
+         selectors: [
+             {
+                 selector_id: 'color 1',
+                 css_selector: 'div.ant-row:nth-child(4) div:nth-child(1)',
+             },
+             {
+                 selector_id: 'color 2',
+                 css_selector: 'div.ant-row:nth-child(4) div:nth-child(2)',
+             },
+         ],
+     }
+     ```
+     */
+    trackParticularClicks?: TrackParticularClicks;
+    /**
+     * Este es otro tracker personalizado de CloudCar y envía eventos 
+     * al collector cada vez que el usuario hace click en el botón de 
+     * compra. Su configuración requiere de una lista de selectores 
+     * correspondientes al botón de compra. El evento que se envía 
+     * consiste de un identificador del vehículo a comprar y el tiempo 
+     * que se demora el usuario en hacer click en el botón desde que 
      * entró a la página.
-        
-        ```
-        trackPurchaseButtonClick: {
-            selectors: [
-                "#botonComprar"
-            ]
-        }
-        ```
-        */
-       trackPurchaseButtonClick?: TrackPurchaseButtonClick;
+     
+     ```
+     trackPurchaseButtonClick: {
+         selectors: [
+             "#botonComprar"
+         ]
+     }
+     ```
+     */
+    trackPurchaseButtonClick?: TrackPurchaseButtonClick;
     /**
      * Este es un tracker personalizado de CloudCar y envía eventos al 
      * collector cada vez que el usuario selecciona texto. Su configuración 
      * solo requiere de un booleano para definir si se implementa o no. El 
      * evento que se envía contiene el texto seleccionado, la posicion del 
      * texto en la pantalla y si el usuario copió ese texto o no.
-
-        ```
-        trackTextSelection: true
-        ```
+     
+     ```
+     trackTextSelection: true
+     ```
      */
     trackTextSelection?: boolean;
     /**
-    * Este es otro tracker personalizado de CloudCar y envía eventos 
-    * al collector cada vez que el usuario hace hover sobre un elemento 
-    * html dentro de la página. 
-    * Su configuración requiere de una lista de selectores 
-    * correspondientes al los distintos elementos HTML que 
-    * se quieren trackear. El evento que se envía 
-    * consiste de un identificador del vehículo observavodo, un identificador del elemento,
-    * el innerText del elemento si es que tiene y el tiempo que el usuario hace hover
-    * sobre este.
-    
-    ```
-    trackHover: {
-        selectors: [
-            {
-                selector_id: 'Purcharse Button',
-                css_selector: '.BaseButton_Button',
-            },
-            {
-                selector_id: 'Car Image',
-                css_selector: '.Widget_ImageHeader',
-            },
-        ],
+     * Este es otro tracker personalizado de CloudCar y envía eventos 
+     * al collector cada vez que el usuario hace hover sobre un elemento 
+     * html dentro de la página. 
+     * Su configuración requiere de una lista de selectores 
+     * correspondientes al los distintos elementos HTML que 
+     * se quieren trackear. El evento que se envía 
+     * consiste de un identificador del vehículo observavodo, un identificador del elemento,
+     * el innerText del elemento si es que tiene y el tiempo que el usuario hace hover
+     * sobre este.
+     
+     ```
+     trackHover: {
+         selectors: [
+             {
+                 selector_id: 'Purcharse Button',
+                 css_selector: '.BaseButton_Button',
+             },
+             {
+                 selector_id: 'Car Image',
+             css_selector: '.Widget_ImageHeader',
+         },
+     ],
     }
     ```
     */
     trackHover?: TrackHover;
-     /**
-     * Este es un tracker personalizado de CloudCar y envía eventos al collector cada vez que el usuario se cambia de step, 
-     * ya sea a través del botón continuar o un botón step. 
-     * Su configuración requiere de una lista de selectores correspondientes al los distintos elementos HTML que se quieren trackear.
-     *  El evento que se envía consiste en el nombre step donde estuvo el usuario, el tiempo que permaneció en el step,
-     *  un identificador del elemento y un identificador del la compra (purchaseIntentId).
-        
+    /**
+    * Este es un tracker personalizado de CloudCar y envía 
+    * eventos al collector cada vez que el usuario se cambia 
+    * de step, ya sea a través del botón continuar o un botón step. 
+    * Su configuración requiere de una lista de selectores 
+    * correspondientes al los distintos elementos HTML que se quieren trackear.
+    *  El evento que se envía consiste en el nombre step donde estuvo el usuario,
+    *  el tiempo que permaneció en el step, un identificador del elemento y
+    *  un identificador del la compra (purchaseIntentId).
+       
        ```
        trackStep: {
            selectors: [
@@ -143,8 +146,23 @@ export type SnowplowConfig = {
            ],
        }
        ```
-     */
+       */
     trackStep?: TrackStep;
+    /**
+    * Este es un tracker personalizado de CloudCar y envía eventos 
+    * al collector cada `time_interval` cantidad de segundos.
+    * Este envia información acerca del estado actual del usuario 
+    * en la página (blur o focus) y la posición del mouse cada 
+    * `mousePosInterval` segundos.
+    * 
+       ```
+       trackPagePingExtended: {
+            time_interval: 30,
+            mousePosInterval: 2
+        }
+       ```
+       */
+    trackPagePingExtended?: TrackPagePingExtended;
 }
 
 export type TrackedElement = {
@@ -155,6 +173,11 @@ export type TrackedElement = {
 
 export type TrackHover = {
     selectors?: (Selector)[];
+}
+
+export type TrackPagePingExtended = {
+    time_interval: number;
+    mousePosInterval: number;
 }
 
 export type TrackParticularClicks = {

--- a/lib/config/configTypes.ts
+++ b/lib/config/configTypes.ts
@@ -43,11 +43,11 @@ export type SnowplowConfig = {
        enableActivityTracking: EnableActivityTracking | boolean;
        /**
         * Este es un tracker personalizado de CloudCar y envía eventos 
-     * al collector cada vez que el usuario hace click en algún elemento 
-     * HTML de interés para la organización. Su configuración requiere de 
-     * una lista de selectores correspondientes a los elementos HTML que 
-     * se quieren trackear, junto con un identificador para reconocerlos 
-     * más adelante en la base de datos.
+        * al collector cada vez que el usuario hace click en algún elemento 
+        * HTML de interés para la organización. Su configuración requiere de 
+        * una lista de selectores correspondientes a los elementos HTML que 
+        * se quieren trackear, junto con un identificador para reconocerlos 
+        * más adelante en la base de datos.
 
         ```
         trackParticularClicks: {
@@ -81,8 +81,8 @@ export type SnowplowConfig = {
             ]
         }
         ```
-     */
-    trackPurchaseButtonClick?: TrackPurchaseButtonClick;
+        */
+       trackPurchaseButtonClick?: TrackPurchaseButtonClick;
     /**
      * Este es un tracker personalizado de CloudCar y envía eventos al 
      * collector cada vez que el usuario selecciona texto. Su configuración 
@@ -95,12 +95,43 @@ export type SnowplowConfig = {
         ```
      */
     trackTextSelection?: boolean;
+    /**
+    * Este es otro tracker personalizado de CloudCar y envía eventos 
+    * al collector cada vez que el usuario hace hover sobre un elemento 
+    * html dentro de la página. 
+    * Su configuración requiere de una lista de selectores 
+    * correspondientes al los distintos elementos HTML que 
+    * se quieren trackear. El evento que se envía 
+    * consiste de un identificador del vehículo observavodo, un identificador del elemento,
+    * el innerText del elemento si es que tiene y el tiempo que el usuario hace hover
+    * sobre este.
+    
+    ```
+    trackHover: {
+        selectors: [
+            {
+                selector_id: 'Purcharse Button',
+                css_selector: '.BaseButton_Button',
+            },
+            {
+                selector_id: 'Car Image',
+                css_selector: '.Widget_ImageHeader',
+            },
+        ],
+    }
+    ```
+    */
+    trackHover?: TrackHover;
 }
 
 export type TrackedElement = {
     id: string;
-    element: Element;
+    element: HTMLElement;
     step: string;
+}
+
+export type TrackHover = {
+    selectors?: (Selector)[];
 }
 
 export type TrackParticularClicks = {

--- a/lib/config/configTypes.ts
+++ b/lib/config/configTypes.ts
@@ -48,7 +48,7 @@ export type SnowplowConfig = {
         * una lista de selectores correspondientes a los elementos HTML que 
         * se quieren trackear, junto con un identificador para reconocerlos 
         * más adelante en la base de datos.
-
+    
         ```
         trackParticularClicks: {
             selectors: [
@@ -122,6 +122,29 @@ export type SnowplowConfig = {
     ```
     */
     trackHover?: TrackHover;
+     /**
+     * Este es un tracker personalizado de CloudCar y envía eventos al collector cada vez que el usuario se cambia de step, 
+     * ya sea a través del botón continuar o un botón step. 
+     * Su configuración requiere de una lista de selectores correspondientes al los distintos elementos HTML que se quieren trackear.
+     *  El evento que se envía consiste en el nombre step donde estuvo el usuario, el tiempo que permaneció en el step,
+     *  un identificador del elemento y un identificador del la compra (purchaseIntentId).
+        
+       ```
+       trackStep: {
+           selectors: [
+               {
+                   selector_id: 'Next Button',
+                   css_selector: '.BaseButton_Button',
+               },
+               {
+                   selector_id: 'Step Button',
+                   css_selector: '.Widget_ImageHeader',
+               },
+           ],
+       }
+       ```
+     */
+    trackStep?: TrackStep;
 }
 
 export type TrackedElement = {
@@ -140,4 +163,8 @@ export type TrackParticularClicks = {
 
 export type TrackPurchaseButtonClick = {
     selectors: (string)[];
+}
+
+export type TrackStep = {
+    selectors?: (Selector)[];
 }

--- a/lib/custom_trackers/hover.ts
+++ b/lib/custom_trackers/hover.ts
@@ -1,0 +1,66 @@
+import { generateJson } from '../tools/generateJson';
+import { getUnseenElements } from '../tools/getUnseenElements';
+import { findParentBySelector } from '../tools/findParentBySelector';
+import { 
+  TrackHover,
+  TrackedElement,
+} from '../config/configTypes';
+import axios from 'axios';
+
+let startTime : number = 0;
+let endTime : number = 0
+let totalTime : number = 0
+
+function sendEvent(collector: string, eventJson: object){
+  axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`, eventJson)
+  .catch((error) => {
+    console.error(error);
+    });
+}
+
+const enterElement = () => {
+  startTime = (new Date()).getTime()
+};
+
+const leaveElement = (collector: string, element_id: string, inner_text: string)=>{
+  endTime =  (new Date()).getTime();
+  totalTime = endTime - startTime
+  startTime = 0
+
+  const buttonContainer: Node | null = (event.target instanceof Element) ? findParentBySelector(event.target, '.cloudcar_button_container') : null
+
+  const eventJson : any = generateJson({
+    id_car: (buttonContainer) ? (<Element> buttonContainer).getAttribute('data-car-group-id') : 'null',
+    identifier: element_id,
+    inner_text: inner_text,
+    time: totalTime 
+  }, "hover", "3-0-0");
+
+  sendEvent(collector, eventJson)
+  restarTimer()
+};
+
+function restarTimer(){
+  startTime = 0
+  endTime = 0
+}
+
+const trackHover= (collector: string, config :TrackHover):void=> {
+  let relevantElementHover: Array<TrackedElement> = [];
+
+  setInterval(() => {
+    //Array of elements from query
+    let newElementHover: Array<TrackedElement> = getUnseenElements(config.selectors, relevantElementHover);
+    //Only elements that are not in relevantElementHover
+    relevantElementHover.push(...newElementHover);
+    //Add event to elements
+    newElementHover.forEach((elementHover: TrackedElement) => {
+      elementHover.element.addEventListener('mouseenter', enterElement);
+      elementHover.element.addEventListener('mouseleave',() => {
+        leaveElement(collector, elementHover.id, elementHover.element.innerText)
+      });
+    })
+  }, 500)
+}
+
+export default trackHover;

--- a/lib/custom_trackers/index.ts
+++ b/lib/custom_trackers/index.ts
@@ -1,9 +1,11 @@
 import trackTextSelection from './text_selection';
 import trackParticularClicks from './particular_clicks';
 import trackPurchaseButtonClick from './purchase_button_click';
+import trackHover from './hover';
 
 export {
     trackTextSelection,
     trackParticularClicks,
-    trackPurchaseButtonClick
+    trackPurchaseButtonClick,
+    trackHover
 };

--- a/lib/custom_trackers/index.ts
+++ b/lib/custom_trackers/index.ts
@@ -3,11 +3,13 @@ import trackParticularClicks from './particular_clicks';
 import trackPurchaseButtonClick from './purchase_button_click';
 import trackStep from './step';
 import trackHover from './hover';
+import trackPagePingExtended from './page_ping_extended';
 
 export {
     trackTextSelection,
     trackParticularClicks,
     trackPurchaseButtonClick,
-    trackStep,
-    trackHover
+    trackHover,
+    trackPagePingExtended,
+    trackStep
 };

--- a/lib/custom_trackers/index.ts
+++ b/lib/custom_trackers/index.ts
@@ -1,11 +1,13 @@
 import trackTextSelection from './text_selection';
 import trackParticularClicks from './particular_clicks';
 import trackPurchaseButtonClick from './purchase_button_click';
+import trackStep from './step';
 import trackHover from './hover';
 
 export {
     trackTextSelection,
     trackParticularClicks,
     trackPurchaseButtonClick,
+    trackStep,
     trackHover
 };

--- a/lib/custom_trackers/page_ping_extended.ts
+++ b/lib/custom_trackers/page_ping_extended.ts
@@ -1,0 +1,63 @@
+/* eslint-disable @typescript-eslint/no-floating-promises */
+import { generateJson } from '../tools/generateJson';
+import { TrackPagePingExtended } from '../config/configTypes';
+import axios from 'axios';
+
+// User has switched back to the tab
+const onFocus = (focusInterval: number[]) => {
+  focusInterval.push(new Date().getTime());
+};
+
+// User has switched away from the tab (AKA tab is hidden)
+const onBlur = (focusInterval: number[]) => {
+  focusInterval.push(new Date().getTime());
+};
+
+const trackPagePingExtended = (collector: string, config :TrackPagePingExtended ): void => {
+  
+  const time_interval: number = config.time_interval
+  const mousePosInterval: number = config.mousePosInterval
+  // Focus intervals
+  const now: number = new Date().getTime();
+  let focusInterval: number[] = [now];
+  const focused = () => {
+    onFocus(focusInterval);
+  };
+  const blurred = () => {
+    onBlur(focusInterval);
+  };
+
+  window.addEventListener('focus', focused);
+  window.addEventListener('blur', blurred);
+
+  // Mouse positions
+  let mousePos: number[] = [];
+  const currentMousePos: number[] = [0, 0];
+  window.addEventListener('mousemove', (event: MouseEvent) => {
+    currentMousePos[0] = event.offsetX;
+    currentMousePos[1] = event.offsetY;
+  });
+
+  setInterval(() => {
+    mousePos.push(currentMousePos[0], currentMousePos[1]);
+  }, mousePosInterval*1000);
+
+  setInterval(() => {
+    const event_json: any = generateJson(
+      {
+        focus_interval: focusInterval,
+        mouse_pos_interval: mousePosInterval,
+        mouse_pos: mousePos,
+      },
+      'page_ping_extended'
+    );
+    axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`, event_json)
+    .catch((error) => {
+      console.error(error);
+      });
+    focusInterval = [];
+    mousePos = [];
+  }, time_interval * 1000);
+};
+
+export default trackPagePingExtended;

--- a/lib/custom_trackers/step.ts
+++ b/lib/custom_trackers/step.ts
@@ -1,0 +1,50 @@
+import generateJson from "../tools/generateJson";
+import { getUnseenElements } from '../tools/getUnseenElements';
+import getPurchaseIntentId from '../tools/getPurchaseIntentIdFromJwt'
+import { 
+  TrackStep,
+  TrackedElement,
+} from '../config/configTypes';
+import axios from 'axios';
+
+let startTime : number = 0;
+
+function finishTimer()
+{
+  let endTime = (new Date()).getTime()
+  let totalTime = endTime - startTime
+  return totalTime
+}
+
+function sendEvent(collector: string){
+  const eventJson : any = generateJson({
+    last_step: window.location.pathname, 
+    time: finishTimer(),
+    purchaseIntentId: '49036c0e-5904-413a-aac0-9f635b7ee837'
+  }, "steps");
+
+  axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`, eventJson)
+  .catch((error) => {
+    console.error(error);
+    });
+  startTime = (new Date()).getTime()
+}
+
+const trackStep = (collector: string, config: TrackStep) => {
+  startTime = (new Date()).getTime()
+
+  let relevantElements: Array<TrackedElement> = [];
+
+  setInterval(() => {
+    //Array of elements from query
+    let newElements: Array<TrackedElement> = getUnseenElements(config.selectors, relevantElements);
+    relevantElements.push(...newElements);
+    newElements.forEach((btnStep: TrackedElement) => {
+        btnStep.element.addEventListener('click', () => {
+          sendEvent(collector)
+        });
+    })
+  }, 500)
+};
+
+export default trackStep;

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -10,6 +10,7 @@ import {
 } from '@snowplow/browser-plugin-geolocation';
 import {
     trackTextSelection,
+    trackPagePingExtended,
     trackParticularClicks,
     trackPurchaseButtonClick,
     trackStep,
@@ -27,7 +28,9 @@ export function enableSnowplow(collectorAddress: string, config: SnowplowConfig)
           webPage: true,
         },
     });
+    
     enableGeolocationContext();
+    
     if (config.enableActivityTracking) {
         enableActivityTracking((typeof config.enableActivityTracking === 'boolean') ? {
             minimumVisitLength: 30,
@@ -36,6 +39,9 @@ export function enableSnowplow(collectorAddress: string, config: SnowplowConfig)
     }
     if (config.trackPageView) {
         trackPageView();
+    }
+    if (config.trackPagePingExtended) {
+        trackPagePingExtended(collectorAddress, config.trackPagePingExtended)
     }
     if (config.trackStep) {
         trackStep(collectorAddress, config.trackStep);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -11,7 +11,8 @@ import {
 import {
     trackTextSelection,
     trackParticularClicks,
-    trackPurchaseButtonClick
+    trackPurchaseButtonClick,
+    trackHover
 } from './custom_trackers/index';
 import { SnowplowConfig } from './config/configTypes'
 
@@ -34,6 +35,9 @@ export function enableSnowplow(collectorAddress: string, config: SnowplowConfig)
     }
     if (config.trackPageView) {
         trackPageView();
+    }
+    if(config.trackHover){
+        trackHover(collectorAddress, config.trackHover);
     }
     if (config.trackTextSelection) {
         trackTextSelection(collectorAddress);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -12,6 +12,7 @@ import {
     trackTextSelection,
     trackParticularClicks,
     trackPurchaseButtonClick,
+    trackStep,
     trackHover
 } from './custom_trackers/index';
 import { SnowplowConfig } from './config/configTypes'
@@ -35,6 +36,9 @@ export function enableSnowplow(collectorAddress: string, config: SnowplowConfig)
     }
     if (config.trackPageView) {
         trackPageView();
+    }
+    if (config.trackStep) {
+        trackStep(collectorAddress, config.trackStep);
     }
     if(config.trackHover){
         trackHover(collectorAddress, config.trackHover);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -4,6 +4,10 @@ import {
     enableActivityTracking,
 } from '@snowplow/browser-tracker';
 import { DebuggerPlugin } from '@snowplow/browser-plugin-debugger';
+import { 
+    GeolocationPlugin, 
+    enableGeolocationContext 
+} from '@snowplow/browser-plugin-geolocation';
 import {
     trackTextSelection,
     trackParticularClicks,
@@ -14,13 +18,14 @@ import { SnowplowConfig } from './config/configTypes'
 export function enableSnowplow(collectorAddress: string, config: SnowplowConfig): void {
     newTracker('cloudcar', collectorAddress, {
         appId: 'cloudcar-snowplow',
-        plugins: [DebuggerPlugin()],
+        plugins: [DebuggerPlugin(), GeolocationPlugin()],
         platform: 'web',
         sessionCookieTimeout: 3600, // in seconds
         contexts: {
           webPage: true,
         },
     });
+    enableGeolocationContext();
     if (config.enableActivityTracking) {
         enableActivityTracking((typeof config.enableActivityTracking === 'boolean') ? {
             minimumVisitLength: 30,

--- a/lib/tools/findParentBySelector.ts
+++ b/lib/tools/findParentBySelector.ts
@@ -1,6 +1,6 @@
 import { collectionHas } from "./collectionHas";
 
-export function findParentBySelector(elm: Element, selector: string): Node | null {
+export function findParentBySelector(element: Element, selector: string): Node | null {
     const all: Array<Element> = Array.from(window.document.querySelectorAll(selector));
     let current: Node | null = element.parentNode;
     while(current && !collectionHas(all, current)) { //keep going up until you find a match

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,29 +1,28 @@
 import { getCookieDomainUserId } from '../tools/getCookieDomainUserId';
 
 export function generateJson(
-  data: unknown,
-  schema: string,
-  version: string = '1-0-0',
-  event_data?: unknown
-): unknown {
-  return {
-    schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
-    data: [
-      {
-        e: 'ue',
-        p: 'web',
-        tv: 'node-1.0.2',
-        duid: getCookieDomainUserId('_sp_id.1fff'),
-        ue_pr: JSON.stringify({
-          schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
-          data: {
-            schema: `iglu:cl.cloudcar/${schema}/jsonschema/${version}`,
-            data,
-          },
-        }),
-      },
-    ],
-  };
-}
-
-export default generateJson;
+    data: unknown,
+    schema: string,
+    version: string = '1-0-0',
+    event_data?: unknown
+  ): unknown {
+    return {
+      schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
+      data: [
+        {
+          e: 'ue',
+          p: 'web',
+          tv: 'node-1.0.2',
+          ue_pr: JSON.stringify({
+            schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
+            data: {
+              schema: `iglu:cl.cloudcar/${schema}/jsonschema/${version}`,
+              data,
+            },
+          }),
+        },
+      ],
+    };
+  }
+  
+  export default generateJson;

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -3,6 +3,7 @@ import { getCookieDomainUserId } from '../tools/getCookieDomainUserId';
 export function generateJson(
   data: unknown,
   schema: string,
+  version: string = '1-0-0',
   event_data?: unknown
 ): unknown {
   return {
@@ -16,7 +17,7 @@ export function generateJson(
         ue_pr: JSON.stringify({
           schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
           data: {
-            schema: `iglu:cl.cloudcar/${schema}/jsonschema/1-0-0`,
+            schema: `iglu:cl.cloudcar/${schema}/jsonschema/${version}`,
             data,
           },
         }),

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,3 +1,5 @@
+import { getCookieDomainUserId } from '../tools/getCookieDomainUserId';
+
 export function generateJson(
   data: unknown,
   schema: string,
@@ -10,6 +12,7 @@ export function generateJson(
         e: 'ue',
         p: 'web',
         tv: 'node-1.0.2',
+        duid: getCookieDomainUserId('_sp_id.1fff'),
         ue_pr: JSON.stringify({
           schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
           data: {

--- a/lib/tools/getCookieDomainUserId.ts
+++ b/lib/tools/getCookieDomainUserId.ts
@@ -1,0 +1,9 @@
+export function getCookieDomainUserId(cookieName) {
+  const value = `; ${document.cookie}`;
+  const parts = value.split(`; ${cookieName}=`);
+  if (parts.length === 2){
+    return parts.pop()?.split(';').shift()?.split('.')[0]; 
+  } 
+}
+
+export default getCookieDomainUserId;

--- a/lib/tools/getPurchaseIntentIdFromJwt.ts
+++ b/lib/tools/getPurchaseIntentIdFromJwt.ts
@@ -1,0 +1,17 @@
+import jwtDecode from 'jwt-decode';
+
+interface JwtToken {
+  'cognito:username'?: string;
+  purchaseIntentId: string;
+}
+
+const getPurchaseIntentId = (): string => {
+  const token = localStorage.getItem('AccessToken') as string;
+  if (token) {
+    const decodedToken: JwtToken = jwtDecode(token);
+    return decodedToken.purchaseIntentId;
+  }
+  return '';
+};
+
+export default getPurchaseIntentId;

--- a/lib/tools/getUnseenElements.ts
+++ b/lib/tools/getUnseenElements.ts
@@ -3,12 +3,18 @@ import {
     Selector,
   } from '../config/configTypes';
 
+
+/**
+ * Este método busca elementos en base a `selectors` 
+ * y retorna los elementos que encuentra y que no
+ * están en `relevantElements`
+ */
 export const getUnseenElements = (selectors: (Selector)[], relevantElements: (TrackedElement)[]): Array<TrackedElement> => {
     let newElements: Array<TrackedElement> = [];
     selectors.forEach((selector: Selector) => {
-        let queryElements: Array<Element> = Array.from(window.document.querySelectorAll(selector.css_selector))
+        let queryElements: Array<HTMLElement> = Array.from(window.document.querySelectorAll(selector.css_selector))
         newElements.push(
-        ...queryElements.map((element: Element) => ({
+        ...queryElements.map((element: HTMLElement) => ({
             id: selector.selector_id,
             step: (selector.step) ? selector.step : '',
             element: element,

--- a/package-lock.json
+++ b/package-lock.json
@@ -186,6 +186,38 @@
         "tslib": "^2.3.0"
       }
     },
+    "@snowplow/browser-plugin-geolocation": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@snowplow/browser-plugin-geolocation/-/browser-plugin-geolocation-3.2.3.tgz",
+      "integrity": "sha512-oraKIMY4lc1woowXdPsB81us59Cg3MUXOLiuLkexgk0cM2/6OhgRMk7FXr4yjhv0CrfsJbrw2iVm3WEV3tzTNw==",
+      "requires": {
+        "@snowplow/browser-tracker-core": "3.2.3",
+        "@snowplow/tracker-core": "3.2.3",
+        "tslib": "^2.3.0"
+      },
+      "dependencies": {
+        "@snowplow/browser-tracker-core": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@snowplow/browser-tracker-core/-/browser-tracker-core-3.2.3.tgz",
+          "integrity": "sha512-ZMlsKC/gxVlclFOwa3SVpz80025vtKgG20Rr9r0rH6MVqgY/g1R7zTUhmFc36pnE68HOUU31iBjth7OpZi+IlA==",
+          "requires": {
+            "@snowplow/tracker-core": "3.2.3",
+            "sha1": "^1.1.1",
+            "tslib": "^2.3.0",
+            "uuid": "^3.4.0"
+          }
+        },
+        "@snowplow/tracker-core": {
+          "version": "3.2.3",
+          "resolved": "https://registry.npmjs.org/@snowplow/tracker-core/-/tracker-core-3.2.3.tgz",
+          "integrity": "sha512-Hx/3atf3iZk2Jj3OGvcykr0S+vTytIQtPVKsbV68+jSV0S5t+SkDMnvb4HgDOGb9XYYseZWd8QZnYU7rUuw0XA==",
+          "requires": {
+            "tslib": "^2.3.0",
+            "uuid": "^3.4.0"
+          }
+        }
+      }
+    },
     "@snowplow/browser-tracker": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/@snowplow/browser-tracker/-/browser-tracker-3.2.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1527,6 +1527,11 @@
         "object.assign": "^4.1.2"
       }
     },
+    "jwt-decode": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-3.1.2.tgz",
+      "integrity": "sha512-UfpWE/VZn0iP50d8cz9NrZLM9lSWhcJ+0Gt/nm4by88UL+J1SiKN8/5dkjMmbEzwL2CAe+67GsegCbIKtbp75A=="
+    },
     "language-subtag-registry": {
       "version": "0.3.21",
       "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "@snowplow/browser-plugin-debugger": "^3.2.1",
     "@snowplow/browser-plugin-geolocation": "^3.2.3",
     "@snowplow/browser-tracker": "^3.2.1",
-    "axios": "^0.25.0"
+    "axios": "^0.25.0",
+    "jwt-decode": "^3.1.2"
   },
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/cloudcar-app"

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@snowplow/browser-plugin-debugger": "^3.2.1",
+    "@snowplow/browser-plugin-geolocation": "^3.2.3",
     "@snowplow/browser-tracker": "^3.2.1",
     "axios": "^0.25.0"
   },


### PR DESCRIPTION
## What?
Se añaden los trackers pagePingExtended, hover, step, y geolocalization. Además, se adaptan trackers ya existentes a nuevas configuraciones y se añaden cookies de identificación de usuario en todos los eventos.

## Why?
El agregar el pagePingExtended permite extender la funcionalidad del enableActivityTracking. El tracker de hover y step permite trackear donde el usuario hace hover y como se comporta al pasar por el flujo de compra, respectivamente. El tracker de geolocalization permite conocer en detalle la ubicación del usuario. Por otro lado, las cookies permiten no perder el rastro de un usuario que se mueve a través de diferentes rutas en el concesionario. Por último, los cambios en las configuraciones permiten identificar con mayor facilidad el elemento con el que interactúa el usuario.

El conjunto de los cambios previamente mencionados permite un mayor entendimiento del comportamiento del usuario, lo que deriva en un análisis más profundo y datos más ricos.

## How?
Para los eventos se desarrolló una configuración específica y un archivo que leía esa configuración, incorporaba los _listeners_ necesarios y gatillaba los eventos ajustándolos a lo que requería el schema asociado. La geolocalización fue diferente al ser un plugin de snowplow. 

Para agregar las cookies, se creó una función que extrae la información de las cookies creadas por snowplow y las añadía al payload general en que se envuelven todos los eventos. De esta manera, todos los eventos enviarían la cookie del usuario y permitiría un trackeo transversal a través de la plataforma.

Para los cambios en la configuración simplemente se cambiaron los tipos correspondientes a las configuraciones que requerían de selectores. Estas dejaron de ser strings y se cambiaron por un objeto que contenía no solo el selector, sino que también un nombre personalizado para identificar el elemento con el que interactúa el usuario.

## Testing?
Para probar que todo funcionara correctamente se utilizaba el repo de button y front, y se revisaba que los eventos se gatillaran siguiendo lo especificado en la configuración de la librería y que posteriormente llegaran a la base de datos en el formato correcto. 

## Screenshots


## Anything Else?
Para mayor detalle de los eventos añadidos se puede revisar el README de la librería.

