### PR TITLE
fix: Update particular clicks schema

### DIFF
--- a/lib/custom_trackers/particular_clicks.ts
+++ b/lib/custom_trackers/particular_clicks.ts
@@ -9,10 +9,11 @@ import axios from 'axios';
 const sendEvent = (collector: string, id: string, step: string, event: Event) => {
   const eventJson: unknown = generateJson(
     {
-      selector_id: id,
+      identifier: id,
       step: step,
     },
-    'particular_clicks'
+    'particular_clicks',
+    '2-0-0'
   );
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`,
     eventJson


### PR DESCRIPTION
## What?
Se cambia la versión de particular clicks utilizada en la librería

## Why?
El schema tenía una propiedad que no era consistente con el resto de los eventos.

## How?
Se le cambió el nombre a la propiedad `selector_id` a `identifier`. Esto significó cambiar también la versión del schema y actualizarla en la librería.

## Testing?
Se clickearon eventos en button y front y estos llegaban correctamente al collector y luego a la base de datos.

## Screenshots


## Anything Else?

