### PR TITLE
Feat/add dynamic config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,15 @@ trackPagePingExtended: {
     mousePosInterval: 2
 }
 ```
+
+#### Sobre `selectors`
+
+Para las configuraciones que utilicen el objeto `selectors`, existe una forma de
+añadir diferentes identificadores para elementos que comparten selector si su identificador se puede encontrar en un atributo del elemento HTML. Para aprovechar esta funcionalidad se debe escribir el identificador (`selector_id`) de la siguiente forma:
+```
+{
+    selector_id: 'Color: #alt#',
+    css_selector: 'div.ant-row:nth-child(4) img',
+}
+```
+En este caso el `css_selector` entregará diferentes `img` que representan un color, y el nombre del color se encuentra en el atributo `alt` del elemento. Finalmente, cuando los elementos gatillen un evento, el identificado de cada uno será: `'Color: Rojo'` o `'Color: Azul'`.

--- a/lib/tools/getUnseenElements.ts
+++ b/lib/tools/getUnseenElements.ts
@@ -1,27 +1,39 @@
-import { 
+import {
     TrackedElement,
     Selector,
-  } from '../config/configTypes';
+} from '../config/configTypes';
 
+const setIdToTrackedElement = (selectorId: string, element: HTMLElement): string => {
+    const substrings: string[] = selectorId.split('#') 
+    if (substrings.length < 3) { return selectorId; }
+    for (let index = 1; index < substrings.length; index += 2) {
+        const substring = substrings[index];
+        substrings[index] = element.getAttribute(substring) || 'null';
+    }
+    return substrings.join('')
+}
 
 /**
  * Este método busca elementos en base a `selectors` 
  * y retorna los elementos que encuentra y que no
  * están en `relevantElements`
  */
-export const getUnseenElements = (selectors: (Selector)[], relevantElements: (TrackedElement)[]): Array<TrackedElement> => {
+export const getUnseenElements = (
+    selectors: (Selector)[], 
+    relevantElements: (TrackedElement)[]
+    ): Array<TrackedElement> => {
     let newElements: Array<TrackedElement> = [];
     selectors.forEach((selector: Selector) => {
         let queryElements: Array<HTMLElement> = Array.from(window.document.querySelectorAll(selector.css_selector))
         newElements.push(
-        ...queryElements.map((element: HTMLElement) => ({
-            id: selector.selector_id,
-            step: (selector.step) ? selector.step : '',
-            element: element,
-        }))
-        ) 
+            ...queryElements.map((element: HTMLElement) => ({
+                id: setIdToTrackedElement(selector.selector_id, element),
+                step: (selector.step) ? selector.step : '',
+                element: element,
+            }))
+        )
     })
     return newElements
         .filter((newElement: TrackedElement) => !relevantElements
-        .some((relevantElement: TrackedElement) => relevantElement.element == newElement.element));
+            .some((relevantElement: TrackedElement) => relevantElement.element == newElement.element));
 }


### PR DESCRIPTION
## What?
Se añade la posibilidad de crear selectores para elementos que se cargan dinámicamente en la página.

## Why?
Esto permite que para eventos como particular clicks, no sea necesario hardcodear los selectores para cada color en caso de que nos interese el click del usuario en los colores. La forma de hacerlo ahora es escribiendo un selector que capture a todos los colores, y en `selector_id` se define entre `#` el atributo del elemento que lo identifica. Por ejemplo, `selector_id: Color: #alt#` pronto se transformará en `selector_id: Color: ROJO` en caso de que el valor del altributo `alt` en algún elemento seleccionado sea ROJO.

## How?
Se creo una función llamada `setIdToTrackedElement` que se encarga de extender la funcionalidad de `getUnseenElements` en caso de que un `selector_id` tenga 2 o más `#`. 

## Testing?
Se probó usando configs con `#` y sin `#` y los eventos se enviaban correctamente.

## Screenshots


## Anything Else?

