### PR TITLE
feat: Identify default values of paticularClicks elements

### DIFF
--- a/lib/custom_trackers/particular_clicks.ts
+++ b/lib/custom_trackers/particular_clicks.ts
@@ -6,14 +6,15 @@ import {
 } from '../config/configTypes';
 import axios from 'axios';
 
-const sendEvent = (collector: string, id: string, step: string, event: Event) => {
+const sendEvent = (collector: string, id: string, step: string, defaultValue: boolean, event?: Event) => {
   const eventJson: unknown = generateJson(
     {
       identifier: id,
       step: step,
+      default_value: defaultValue
     },
     'particular_clicks',
-    '2-0-0'
+    '3-0-0'
   );
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`,
     eventJson
@@ -28,8 +29,9 @@ const trackParticularClicks = (collector: string, config: TrackParticularClicks)
     let newElements: Array<TrackedElement> = getUnseenElements(config.selectors, relevantElements);
     relevantElements.push(...newElements);
     newElements.forEach((trackedElement: TrackedElement) => {
+      sendEvent(collector, trackedElement.id, trackedElement.step, true);
       trackedElement.element.addEventListener('click', (event: Event) => {
-        sendEvent(collector, trackedElement.id, trackedElement.step, event);
+        sendEvent(collector, trackedElement.id, trackedElement.step, false, event);
       });
     }) 
   }, 500)


### PR DESCRIPTION
## What?
Se actualiza el schema de particular clicks para permitir que se identifiquen los valores defaut que toman los elementos de interes una vez que cargan en la página.

## Why?
De esta manera podremos saber que opciones tenía el usuario paraclickear incluso si no las clickeó.

## How?
Además de añadir el listener que envía eventos una vez que los elementos de interés son clickeados, se envía un primer evento en el momento en el que el elemento se carga en la página. Este evento viene acompañado de una nueva propiedad que indica si el evento es de tipo default o no.

## Testing?
Se probó con el button que los particular clicks tuvieran el comportamiento esperado.

## Screenshots


## Anything Else?

