### PR TITLE
feat: Add session_id to custom events

### DIFF
--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -14,6 +14,7 @@ export function generateJson(
           p: 'web',
           tv: 'node-1.0.2',
           duid: getCookieByName('_sp_id.1fff')?.split('.')[0],
+          sid: getCookieByName('_sp_id.1fff')?.split('.')[5],
           ue_pr: JSON.stringify({
             schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
             data: {


### PR DESCRIPTION
## What?
Se añadió la cookie domain_sessionid a los eventos customizados, la cual sirve para registrar la sesión de cada usuario en la pagina.

## Why?
Se añadió porque es necesario para hacer el recorrido del cliente a través del flujo de compra.

## How?
Se añadió la cookie al context de los eventos custom, de manera de que todos lleguen a la BD con esta cookie.

## Testing?
Se testeo probando que los eventos llegaran a la BD con la cookie.

## Screenshots


## Anything Else?

