### PR TITLE
feat: Add getSnowplowCookie function

### DIFF
--- a/lib/tools/cookieManager.ts
+++ b/lib/tools/cookieManager.ts
@@ -27,9 +27,28 @@ const getCookieByName = (cookieName: string) => {
     }
 }
 
+function getSnowplowCookie(cookieName: string) {
+    var matcher = new RegExp('_sp_' + 'id\\.[a-f0-9]+=([^;]+);?');
+    var match = document.cookie.match(matcher);
+    if (match && match[1]) {
+        if(cookieName == "duid"){
+            return match[1].split('.')[0];
+        }
+        else if(cookieName == "sid"){
+            return match[1].split('.')[5];
+        }
+        else{
+            false
+        }
+    } else {
+      return false;
+    }
+}
+
 export {
     createCookie,
     updateCookie,
     checkIfdCookieExists,
-    getCookieByName
+    getCookieByName,
+    getSnowplowCookie
 };

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,4 +1,4 @@
-import { getCookieByName } from './cookieManager';
+import { getSnowplowCookie } from './cookieManager';
 
 export function generateJson(
     data: unknown,
@@ -13,8 +13,8 @@ export function generateJson(
           e: 'ue',
           p: 'web',
           tv: 'node-1.0.2',
-          duid: getCookieByName('_sp_id.1fff')?.split('.')[0],
-          sid: getCookieByName('_sp_id.1fff')?.split('.')[5],
+          duid: getSnowplowCookie('duid'),
+          sid: getSnowplowCookie('sid'),
           ue_pr: JSON.stringify({
             schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
             data: {


### PR DESCRIPTION
## What?
Se añadio la funcion getSnowplowCookie a cookieManager

## Why?
Se añadió ya que las cookies de snowplow no siempre se obtenían, debido a que utilizando la funcion getCookieByName se hardcodeba un poco el nombre, lo que evitaba obtenerla en algunas ocasiones debido a su id (ejemplo: _sp_id.XXXX), por lo cual ahora se utiliza regex para obtener la cookie independiente de su id.

## How?
Se creó la función _getSnowplowCookie_ que obtiene la cookie independientemente de su id, utilizado regex. Además el código es más legible y escalable 

## Testing?
Se testo probando que los eventos llegaran con ambas cookies, tanto domain_userid como domain_sessionid

## Screenshots


## Anything Else?

