### PR TITLE
fix: Fix get snowplow cookies

### DIFF
--- a/lib/config/generalContexts.ts
+++ b/lib/config/generalContexts.ts
@@ -1,0 +1,3 @@
+import { createContexts } from "../tools/createContexts";
+
+export const generalContexts = createContexts([])

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -1,0 +1,13 @@
+export interface EventPayload {
+    schema: string;
+    data?: (EventData)[] | null;
+}
+export interface EventData {
+    e: string;
+    p: string;
+    co?: string;
+    sid: any;
+    tv: string;
+    duid: any;
+    ue_pr: string;
+}

--- a/lib/custom_trackers/hover.ts
+++ b/lib/custom_trackers/hover.ts
@@ -6,6 +6,11 @@ import {
   TrackedElement,
 } from '../config/configTypes';
 import axios from 'axios';
+import {
+  createContexts,
+  Context
+} from '../tools/createContexts';
+import { getCarInfo } from '../tools/getCarInfo';
 
 let startTime : number = (new Date()).getTime();
 let endTime : number = (new Date()).getTime();
@@ -28,13 +33,33 @@ const leaveElement = (collector: string, element_id: string, inner_text: string)
   startTime = (new Date()).getTime();
 
   const buttonContainer: Node | null = (event.target instanceof Element) ? findParentBySelector(event.target, '.cloudcar_button_container') : null
-
+  const contexts: Context[] = []
+  if (buttonContainer) {
+    contexts.push(
+      {
+      name: 'car_context',
+      version: '1-0-0',
+      data: getCarInfo(<HTMLElement>buttonContainer)
+    },
+    {
+      name: 'concessionaire_context',
+      version: '1-0-0',
+      data: {
+        concessionaire_name: (<HTMLElement>buttonContainer).getAttribute('data-concessionaire-name')
+      },
+    },
+    )
+  }
   const eventJson : any = generateJson({
     id_car: (buttonContainer) ? (<Element> buttonContainer).getAttribute('data-car-group-id') : 'null',
     identifier: element_id,
     inner_text: inner_text,
     time: totalTime 
-  }, "hover", "3-0-0");
+  }, 
+  "hover",
+  "3-0-0",
+  createContexts(contexts)
+  );
 
   sendEvent(collector, eventJson)
   restarTimer()

--- a/lib/custom_trackers/particular_clicks.ts
+++ b/lib/custom_trackers/particular_clicks.ts
@@ -6,14 +6,15 @@ import {
 } from '../config/configTypes';
 import axios from 'axios';
 
-const sendEvent = (collector: string, id: string, step: string, event: Event) => {
+const sendEvent = (collector: string, id: string, step: string, defaultValue: boolean, event?: Event) => {
   const eventJson: unknown = generateJson(
     {
       identifier: id,
       step: step,
+      default_value: defaultValue
     },
     'particular_clicks',
-    '2-0-0'
+    '3-0-0'
   );
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`,
     eventJson
@@ -28,8 +29,9 @@ const trackParticularClicks = (collector: string, config: TrackParticularClicks)
     let newElements: Array<TrackedElement> = getUnseenElements(config.selectors, relevantElements);
     relevantElements.push(...newElements);
     newElements.forEach((trackedElement: TrackedElement) => {
+      sendEvent(collector, trackedElement.id, trackedElement.step, true);
       trackedElement.element.addEventListener('click', (event: Event) => {
-        sendEvent(collector, trackedElement.id, trackedElement.step, event);
+        sendEvent(collector, trackedElement.id, trackedElement.step, false, event);
       });
     }) 
   }, 500)

--- a/lib/custom_trackers/particular_clicks.ts
+++ b/lib/custom_trackers/particular_clicks.ts
@@ -1,12 +1,36 @@
 import { generateJson } from '../tools/generateJson';
 import { getUnseenElements } from '../tools/getUnseenElements';
-import { 
+import {
+  createContexts,
+  Context
+} from '../tools/createContexts';
+import { findParentBySelector } from '../tools/findParentBySelector';
+import { getCarInfo } from '../tools/getCarInfo';
+import {
   TrackParticularClicks,
   TrackedElement,
 } from '../config/configTypes';
 import axios from 'axios';
 
-const sendEvent = (collector: string, id: string, step: string, defaultValue: boolean, event?: Event) => {
+const sendEvent = (collector: string, id: string, step: string, defaultValue: boolean, target: HTMLElement) => {
+  const buttonContainer: Node | null = findParentBySelector(target, '.cloudcar_button_container') || null
+  const contexts: Context[] = []
+  if (buttonContainer) {
+    contexts.push(
+      {
+      name: 'car_context',
+      version: '1-0-0',
+      data: getCarInfo(<HTMLElement>buttonContainer)
+    },
+    {
+      name: 'concessionaire_context',
+      version: '1-0-0',
+      data: {
+        concessionaire_name: (<HTMLElement>buttonContainer).getAttribute('data-concessionaire-name')
+      },
+    },
+    )
+  }
   const eventJson: unknown = generateJson(
     {
       identifier: id,
@@ -14,7 +38,8 @@ const sendEvent = (collector: string, id: string, step: string, defaultValue: bo
       default_value: defaultValue
     },
     'particular_clicks',
-    '3-0-0'
+    '3-0-0',
+    createContexts(contexts)
   );
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`,
     eventJson
@@ -29,11 +54,11 @@ const trackParticularClicks = (collector: string, config: TrackParticularClicks)
     let newElements: Array<TrackedElement> = getUnseenElements(config.selectors, relevantElements);
     relevantElements.push(...newElements);
     newElements.forEach((trackedElement: TrackedElement) => {
-      sendEvent(collector, trackedElement.id, trackedElement.step, true);
+      sendEvent(collector, trackedElement.id, trackedElement.step, true, trackedElement.element);
       trackedElement.element.addEventListener('click', (event: Event) => {
-        sendEvent(collector, trackedElement.id, trackedElement.step, false, event);
+        sendEvent(collector, trackedElement.id, trackedElement.step, false, trackedElement.element);
       });
-    }) 
+    })
   }, 500)
 };
 

--- a/lib/tools/cookieManager.ts
+++ b/lib/tools/cookieManager.ts
@@ -27,9 +27,28 @@ const getCookieByName = (cookieName: string) => {
     }
 }
 
+function getSnowplowCookie(cookieName: string) {
+    var matcher = new RegExp('_sp_' + 'id\\.[a-f0-9]+=([^;]+);?');
+    var match = document.cookie.match(matcher);
+    if (match && match[1]) {
+        if(cookieName == "duid"){
+            return match[1].split('.')[0];
+        }
+        else if(cookieName == "sid"){
+            return match[1].split('.')[5];
+        }
+        else{
+            false
+        }
+    } else {
+      return false;
+    }
+}
+
 export {
     createCookie,
     updateCookie,
     checkIfdCookieExists,
-    getCookieByName
+    getCookieByName,
+    getSnowplowCookie
 };

--- a/lib/tools/createContexts.ts
+++ b/lib/tools/createContexts.ts
@@ -1,0 +1,15 @@
+export type Context = {
+    name: string,
+    version: string,
+    data: object,
+}
+
+export function createContexts(contexts: Context[]) {
+    contexts.forEach((element: Context, index: number, contextsArray: unknown[]) => {
+        contextsArray[index] = {
+            schema: `iglu:cl.cloudcar/${element.name}/jsonschema/${element.version}`,
+            data: element.data
+        }
+    })
+    return contexts
+}

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -14,6 +14,7 @@ export function generateJson(
           p: 'web',
           tv: 'node-1.0.2',
           duid: getCookieByName('_sp_id.1fff')?.split('.')[0],
+          sid: getCookieByName('_sp_id.1fff')?.split('.')[5],
           ue_pr: JSON.stringify({
             schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
             data: {

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,30 +1,51 @@
+export default generateJson;
+import { generalContexts } from '../config/generalContexts';
+import {
+  EventPayload,
+  EventData
+} from '../config/types';
 import { getSnowplowCookie } from './cookieManager';
 
+const addContexts = (
+  eventJson: EventPayload,
+  generalContexts: unknown[],
+  particularContexts: unknown[],
+): unknown => {
+  if (!generalContexts && !particularContexts) { return eventJson }
+  const contextsJson: string = JSON.stringify({
+    schema: "iglu:com.snowplowanalytics.snowplow/contexts/jsonschema/1-0-0",
+    data: generalContexts.concat(particularContexts)
+  })
+  eventJson.data![0].co = contextsJson;
+  return eventJson;
+}
+
 export function generateJson(
-    data: unknown,
-    schema: string,
-    version: string = '1-0-0',
-    event_data?: unknown
-  ): unknown {
-    return {
-      schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
-      data: [
-        {
-          e: 'ue',
-          p: 'web',
-          tv: 'node-1.0.2',
-          duid: getSnowplowCookie('duid'),
-          sid: getSnowplowCookie('sid'),
-          ue_pr: JSON.stringify({
-            schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
-            data: {
-              schema: `iglu:cl.cloudcar/${schema}/jsonschema/${version}`,
-              data,
-            },
-          }),
-        },
-      ],
-    };
+  data: unknown,
+  schema: string,
+  version: string = '1-0-0',
+  particularContexts: unknown[] = [],
+  event_data?: unknown
+): unknown {
+  const eventJson = {
+    schema: 'iglu:com.snowplowanalytics.snowplow/payload_data/jsonschema/1-0-4',
+    data: [
+      {
+        e: 'ue',
+        p: 'web',
+        tv: 'node-1.0.2',
+        duid: getSnowplowCookie('duid'),
+        sid: getSnowplowCookie('sid'),
+        ue_pr: JSON.stringify({
+          schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
+          data: {
+            schema: `iglu:cl.cloudcar/${schema}/jsonschema/${version}`,
+            data,
+          },
+        }),
+      },
+    ],
   }
-  
-  export default generateJson;
+  addContexts(eventJson, generalContexts, particularContexts)
+  return eventJson;
+}

--- a/lib/tools/generateJson.ts
+++ b/lib/tools/generateJson.ts
@@ -1,4 +1,4 @@
-import { getCookieByName } from './cookieManager';
+import { getSnowplowCookie } from './cookieManager';
 
 export function generateJson(
     data: unknown,
@@ -13,8 +13,8 @@ export function generateJson(
           e: 'ue',
           p: 'web',
           tv: 'node-1.0.2',
-          duid: getCookieByName('_sp_id.1fff')?.split('.')[0],
-          sid: getCookieByName('_sp_id.1fff')?.split('.')[5],
+          duid: getSnowplowCookie('duid'),
+          sid: getSnowplowCookie('sid'),
           ue_pr: JSON.stringify({
             schema: 'iglu:com.snowplowanalytics.snowplow/unstruct_event/jsonschema/1-0-0',
             data: {

--- a/lib/tools/getCarInfo.ts
+++ b/lib/tools/getCarInfo.ts
@@ -1,0 +1,20 @@
+export function getCarInfo(buttonContainer: HTMLElement): object {
+    return {
+        carName: (() => {
+            return (<HTMLElement>buttonContainer.querySelector('[class*=\'Widget_Title\']')).innerText
+        })(),
+        year: (() => {
+            const yearString: string = (<HTMLElement>buttonContainer.querySelector('[class*=\'Widget_Subtitle\']'))
+                .innerText
+                .split(' ')[1]
+                .trim()
+            return parseInt(yearString)
+        })(),
+        version: (() => {
+            return (<HTMLElement>buttonContainer.querySelector('[class*=\'Widget_ActiveButton\'] span')).innerText 
+        })(),
+        colorName: (() => {
+            return (<HTMLElement>buttonContainer.querySelector('[class*=\'Widget_ColorName\']')).innerText
+        })()
+    };
+}


### PR DESCRIPTION
## What?
Se añadio la funcion getSnowplowCookie a cookieManager, debido a que no se estaba obteniendo bien las snowplow cookies

## Why?
Se añadió ya que las cookies de snowplow no siempre se obtenían, debido a que utilizando la funcion getCookieByName se hardcodeba un poco el nombre, lo que evitaba obtenerla en algunas ocasiones debido a su id (ejemplo: _sp_id.XXXX), por lo cual ahora se utiliza regex para obtener la cookie independiente de su id.

## How?
Se creó la función getSnowplowCookie que obtiene la cookie independientemente de su id, utilizado regex. Además el código es más legible y escalable.

## Testing?
Se testo probando que los eventos llegaran con ambas cookies, tanto domain_userid como domain_sessionid

## Screenshots


## Anything Else?

