### PR TITLE
fix: Change hardcoded purchaseIntentId in step

### DIFF
--- a/lib/custom_trackers/step.ts
+++ b/lib/custom_trackers/step.ts
@@ -20,7 +20,7 @@ function sendEvent(collector: string, stepName: string){
   const eventJson : any = generateJson({
     last_step: stepName, 
     time: finishTimer(),
-    purchaseIntentId: '49036c0e-5904-413a-aac0-9f635b7ee837'
+    purchaseIntentId: getPurchaseIntentId()
   }, "steps");
 
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`, eventJson)


### PR DESCRIPTION
## What?
Se cambia un purchaseIntentId hardcodeado de step por una función que obtiene el valor correctamente

## Why?
De esta forma no se distorciona la información en la base de datos

## How?
Se obtuvo la función del front, pero nunca se había implementado

## Testing?
Se probó y efectivamente llega el purchaseIntend id correspondiente

## Screenshots


## Anything Else?

