### PR TITLE
feat: Add concessionaire context to all events

### DIFF
--- a/lib/config/generalContexts.ts
+++ b/lib/config/generalContexts.ts
@@ -1,3 +1,11 @@
 import { createContexts } from "../tools/createContexts";
 
-export const generalContexts = createContexts([])
+export const generalContexts = createContexts([
+    {
+        name: 'concessionaire_context',
+        version: '1-0-0',
+        data: {
+            concessionaire_name: (<HTMLElement>document.querySelector('.cloudcar_button_container')).getAttribute('data-concessionaire-name')
+        }
+    }
+])

--- a/lib/custom_trackers/hover.ts
+++ b/lib/custom_trackers/hover.ts
@@ -37,17 +37,10 @@ const leaveElement = (collector: string, element_id: string, inner_text: string)
   if (buttonContainer) {
     contexts.push(
       {
-      name: 'car_context',
-      version: '1-0-0',
-      data: getCarInfo(<HTMLElement>buttonContainer)
-    },
-    {
-      name: 'concessionaire_context',
-      version: '1-0-0',
-      data: {
-        concessionaire_name: (<HTMLElement>buttonContainer).getAttribute('data-concessionaire-name')
+        name: 'car_context',
+        version: '1-0-0',
+        data: getCarInfo(<HTMLElement>buttonContainer)
       },
-    },
     )
   }
   const eventJson : any = generateJson({

--- a/lib/custom_trackers/particular_clicks.ts
+++ b/lib/custom_trackers/particular_clicks.ts
@@ -18,17 +18,10 @@ const sendEvent = (collector: string, id: string, step: string, defaultValue: bo
   if (buttonContainer) {
     contexts.push(
       {
-      name: 'car_context',
-      version: '1-0-0',
-      data: getCarInfo(<HTMLElement>buttonContainer)
-    },
-    {
-      name: 'concessionaire_context',
-      version: '1-0-0',
-      data: {
-        concessionaire_name: (<HTMLElement>buttonContainer).getAttribute('data-concessionaire-name')
+        name: 'car_context',
+        version: '1-0-0',
+        data: getCarInfo(<HTMLElement>buttonContainer)
       },
-    },
     )
   }
   const eventJson: unknown = generateJson(

--- a/lib/custom_trackers/step.ts
+++ b/lib/custom_trackers/step.ts
@@ -20,7 +20,7 @@ function sendEvent(collector: string, stepName: string){
   const eventJson : any = generateJson({
     last_step: stepName, 
     time: finishTimer(),
-    purchaseIntentId: '49036c0e-5904-413a-aac0-9f635b7ee837'
+    purchaseIntentId: getPurchaseIntentId()
   }, "steps");
 
   axios.post(`${collector}/com.snowplowanalytics.snowplow/tp2`, eventJson)

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -19,6 +19,7 @@ import {
 import { SnowplowConfig } from './config/configTypes';
 import { getCookieByName } from './tools/cookieManager';
 import { setUserMailCookie  } from './tools/setUserMailCookie ';
+import { findParentBySelector } from './tools/findParentBySelector';
 
 export function enableSnowplow(collectorAddress: string, config: SnowplowConfig): void {
     newTracker('cloudcar', collectorAddress, {
@@ -42,12 +43,20 @@ export function enableSnowplow(collectorAddress: string, config: SnowplowConfig)
     }
     if (config.trackPageView) {
         trackPageView({
-            context: [{
-                schema: 'iglu:cl.cloudcar/email_context/jsonschema/2-0-0',
-                data: {
-                  email: getCookieByName('userMail') || ''
-                }
-              }],
+            context: [
+                {
+                    schema: 'iglu:cl.cloudcar/email_context/jsonschema/2-0-0',
+                    data: {
+                    email: getCookieByName('userMail') || ''
+                    }
+                },
+                {
+                    schema: 'iglu:cl.cloudcar/concessionaire_context/jsonschema/1-0-0',
+                    data: {
+                        concessionaire_name: (<HTMLElement>document.querySelector('.cloudcar_button_container')).getAttribute('data-concessionaire-name')
+                    }
+                },
+            ],
         });
     }
     if (config.trackPagePingExtended) {


### PR DESCRIPTION
## What?
Se añade el contexto del concesionario a todos los eventos

## Why?
De esta forma no se mezclaran los eventos de diferentes concesionarias y será posible crear dashboards para cada una.

## How?
Se añade el contexto en el archivo `config/generalContexts.js` para que todos los eventos custom lo tengan y también se añade a `page_view` (y en consecuencia a los `page_pings`) 

## Testing?
Se probaron todos los eventos y llegaban a la base de datos como siempre pero también aparecían los contextos añadidos

## Screenshots


## Anything Else?

